### PR TITLE
Inspect all field values that are pids

### DIFF
--- a/test/logger_logstash_backend_test.exs
+++ b/test/logger_logstash_backend_test.exs
@@ -61,6 +61,29 @@ defmodule LoggerLogstashBackendTest do
     assert (now - ts) < 1000
   end
 
+  test "can log pids" do
+    Logger.info "pid", [pid_key: self]
+    json = get_log
+    {:ok, data} = JSX.decode json
+    assert data["type"] === "some_app"
+    assert data["message"] === "pid"
+    expected = %{
+      "function" => "test can log pids/1",
+      "level" => "info",
+      "module" => "Elixir.LoggerLogstashBackendTest",
+      "pid" => (inspect self),
+      "pid_key" => inspect(self),
+      "some_metadata" => "go here",
+      "line" => 65
+    }
+    assert contains?(data["fields"], expected)
+    {:ok, ts} = Timex.parse data["@timestamp"], "%FT%T%z", :strftime
+    ts = Timex.to_unix ts
+
+    now = Timex.to_unix Timex.DateTime.local
+    assert (now - ts) < 1000
+  end
+
   test "cant log when minor levels" do
     Logger.debug "hello world", [key1: "field1"]
     :nothing_received = get_log


### PR DESCRIPTION
# Changelog

## Bug Fixes
* Previously, only the `pid` key of the metadata would be inspected before being passed as the fields value of the map that is encoded by `JSX.encode`, but a pid can appear in other fields, so all field values are now escaped with `inspect` if they are pids.  This prevents a MatchError happening because JSX.encode would return `{:error, :badarg}` if it tried to encode a pid.