### PR TITLE
Use extended ISO format for timestamp for millisecond precision

### DIFF
--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -60,7 +60,7 @@ defmodule LoggerLogstashBackend do
     ts = Timex.to_datetime ts, Timezone.local
     {:ok, json} = JSX.encode %{
       type: type,
-      "@timestamp": Timex.format!(ts, "%FT%T%z", :strftime),
+      "@timestamp": Timex.format!(ts, "{ISO:Extended}"),
       message: to_string(msg),
       fields: fields
     }

--- a/test/logger_logstash_backend_test.exs
+++ b/test/logger_logstash_backend_test.exs
@@ -54,7 +54,7 @@ defmodule LoggerLogstashBackendTest do
       "key1" => "field1"
     }
     assert contains?(data["fields"], expected)
-    {:ok, ts} = Timex.parse data["@timestamp"], "%FT%T%z", :strftime
+    {:ok, ts} = Timex.parse data["@timestamp"], "{ISO:Extended}"
     ts = Timex.to_unix ts
 
     now = Timex.to_unix Timex.local
@@ -77,7 +77,7 @@ defmodule LoggerLogstashBackendTest do
       "line" => 65
     }
     assert contains?(data["fields"], expected)
-    {:ok, ts} = Timex.parse data["@timestamp"], "%FT%T%z", :strftime
+    {:ok, ts} = Timex.parse data["@timestamp"], "{ISO:Extended}"
     ts = Timex.to_unix ts
 
     now = Timex.to_unix Timex.local


### PR DESCRIPTION
There are three forks which are just adding millisecond precision. I'm about to do the same.