### PR TITLE
Removed all occurences of type for logstash 6.0.0

### DIFF
--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -54,7 +54,6 @@ defmodule LoggerLogstashBackend do
     level, msg, ts, md, %{
       host: host,
       port: port,
-      type: type,
       metadata: metadata,
       socket: socket
     }
@@ -71,7 +70,6 @@ defmodule LoggerLogstashBackend do
     )
     ts = Timex.to_datetime ts, Timezone.local
     {:ok, json} = JSX.encode %{
-      type: type,
       "@timestamp": Timex.format!(ts, "{ISO:Extended}"),
       message: to_string(msg),
       fields: fields
@@ -86,7 +84,6 @@ defmodule LoggerLogstashBackend do
 
     level = Keyword.get opts, :level, :debug
     metadata = Keyword.get opts, :metadata, []
-    type = Keyword.get opts, :type, "elixir"
     host = Keyword.get opts, :host
     port = Keyword.get opts, :port
     {:ok, socket} = :gen_udp.open 0
@@ -96,7 +93,6 @@ defmodule LoggerLogstashBackend do
       port: port,
       level: level,
       socket: socket,
-      type: type,
       metadata: metadata
     }
   end

--- a/test/logger_logstash_backend_test.exs
+++ b/test/logger_logstash_backend_test.exs
@@ -26,7 +26,6 @@ defmodule LoggerLogstashBackendTest do
       host: "127.0.0.1",
       port: 10001,
       level: :info,
-      type: "some_app",
       metadata: [
         some_metadata: "go here"
       ]
@@ -42,7 +41,6 @@ defmodule LoggerLogstashBackendTest do
     Logger.info "hello world", [key1: "field1"]
     json = get_log()
     {:ok, data} = JSX.decode json
-    assert data["type"] === "some_app"
     assert data["message"] === "hello world"
     expected = %{
       "function" => "test can log/1",
@@ -65,7 +63,6 @@ defmodule LoggerLogstashBackendTest do
     Logger.info "pid", [pid_key: self()]
     json = get_log()
     {:ok, data} = JSX.decode json
-    assert data["type"] === "some_app"
     assert data["message"] === "pid"
     expected = %{
       "function" => "test can log pids/1",

--- a/test/logger_logstash_backend_test.exs
+++ b/test/logger_logstash_backend_test.exs
@@ -48,7 +48,7 @@ defmodule LoggerLogstashBackendTest do
       "module" => "Elixir.LoggerLogstashBackendTest",
       "pid" => (inspect self()),
       "some_metadata" => "go here",
-      "line" => 42,
+      "line" => 41,
       "key1" => "field1"
     }
     assert contains?(data["fields"], expected)
@@ -71,7 +71,7 @@ defmodule LoggerLogstashBackendTest do
       "pid" => (inspect self()),
       "pid_key" => inspect(self()),
       "some_metadata" => "go here",
-      "line" => 65
+      "line" => 63
     }
     assert contains?(data["fields"], expected)
     {:ok, ts} = Timex.parse data["@timestamp"], "{ISO:Extended}"


### PR DESCRIPTION
This is a small change to reflect the changes to types in Logstash 6.0.0

[https://www.elastic.co/guide/en/elasticsearch/reference/current/_basic_concepts.html#_type](https://www.elastic.co/guide/en/elasticsearch/reference/current/_basic_concepts.html#_type)