### PR TITLE
Send milliseconds in timestamp to Logstash. Reduce dependencies. Add TCP (+optional SSL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: elixir
 elixir:
-  - 1.3.0
   - 1.4.0
   - 1.5.0
 otp_release:
   - 18.0
-

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ that will send logs to the [Logstash UDP input](https://www.elastic.co/guide/en/
  be merged with the metadata sent in every log message.
  * **level**: Atom. Minimum level for this backend.
  * **type**: String.t. Type of logs. Useful to filter in logstash.
+ * **timezone**: String.t. Server timezone. Used to convert from naive timestamp. Default `"Etc/UTC"`.
+ * **json_encoder**: Atom. Module to be used for JSON encoding. Default `Jason`.
 
 ## Sample Logstash config
 ```
@@ -51,7 +53,7 @@ Add logger and tzdata as applications:
 
 ```elixir
 def application do
-  [applications: [:logger, :timex]]
+  [applications: [:logger]]
 end
 ```
 
@@ -81,5 +83,7 @@ config :logger, :error_log,
   type: "my_type_of_app_or_node",
   metadata: [
     extra_fields: "go here"
-  ]
+  ],
+  timezone: "Etc/UTC",
+  json_encoder: Jason
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ that will send logs to the [Logstash UDP input](https://www.elastic.co/guide/en/
  * **level**: Atom. Minimum level for this backend.
  * **type**: String.t. Type of logs. Useful to filter in logstash.
  * **timezone**: String.t. Server timezone. Used to convert from naive timestamp. Default `"Etc/UTC"`.
- * **json_encoder**: Atom. Module to be used for JSON encoding. Default `Jason`.
+ * **json_encoder**: Atom. Module to be used for JSON encoding. The default is `Jason`, add it to your mix deps to use.
 
 ## Sample Logstash config
 ```

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -173,7 +173,7 @@ defmodule LoggerLogstashBackend do
 
   defp open_socket(%{protocol: :udp, socket: nil} = state) do
     case :gen_udp.open(0) do
-      {:ok, socket} -> Map.put(state, :socket, socket)
+      {:ok, socket} -> Map.merge(state, %{socket: socket, recorded_error: false})
       {:error, reason} -> log_error(reason, state)
     end
   end
@@ -182,7 +182,7 @@ defmodule LoggerLogstashBackend do
     with {:ok, socket} <-
            :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}]),
          {:ok, socket} <- :ssl.connect(socket, fail_if_no_peer_cert: true) do
-      Map.put(state, :socket, socket)
+      Map.merge(state, %{socket: socket, recorded_error: false})
     else
       {:error, reason} -> log_error(reason, state)
     end
@@ -191,7 +191,7 @@ defmodule LoggerLogstashBackend do
   defp open_socket(%{protocol: :tcp, socket: nil} = state) do
     :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}])
     |> case do
-      {:ok, socket} -> Map.put(state, :socket, socket)
+      {:ok, socket} -> Map.merge(state, %{socket: socket, recorded_error: false})
       {:error, reason} -> log_error(reason, state)
     end
   end

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -91,15 +91,15 @@ defmodule LoggerLogstashBackend do
     send_log(state, json)
   end
 
-  defp send_log(%{protocol: :udp, socket: socket, host: host, port: port} = state, json) do
+  defp send_log(%{protocol: :udp, socket: socket, host: host, port: port}, json) do
     :gen_udp.send(socket, host, port, [json, "\n"])
   end
 
-  defp send_log(%{protocol: :tcp, ssl: true, socket: socket} = state, json) do
+  defp send_log(%{protocol: :tcp, ssl: true, socket: socket}, json) do
     :ssl.send(socket, [json, "\n"])
   end
 
-  defp send_log(%{protocol: :tcp, socket: socket} = state, json) do
+  defp send_log(%{protocol: :tcp, socket: socket}, json) do
     :gen_tcp.send(socket, [json, "\n"])
   end
 

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -204,8 +204,14 @@ defmodule LoggerLogstashBackend do
 
   defp open_socket(%{protocol: :tcp, ssl: true, socket: nil} = state) do
     with {:ok, socket} <-
-           :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}]),
-         {:ok, socket} <- :ssl.connect(socket, fail_if_no_peer_cert: true) do
+           :gen_tcp.connect(state.host, state.port, [
+             {:active, true},
+             :binary,
+             {:keepalive, true},
+             {:send_timeout, 5000},
+             {:send_timeout_close, true}
+           ]),
+         {:ok, socket} <- :ssl.connect(socket, [fail_if_no_peer_cert: true], 5000) do
       Map.merge(state, %{socket: socket, recorded_error: false})
     else
       {:error, reason} -> log_error(reason, state)
@@ -216,8 +222,14 @@ defmodule LoggerLogstashBackend do
     :gen_tcp.connect(
       state.host,
       state.port,
-      [{:active, true}, :binary, {:keepalive, true}, {:send_timeout, 10_000}],
-      10_000
+      [
+        {:active, true},
+        :binary,
+        {:keepalive, true},
+        {:send_timeout, 5000},
+        {:send_timeout_close, true}
+      ],
+      5000
     )
     |> case do
       {:ok, socket} -> Map.merge(state, %{socket: socket, recorded_error: false})

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -189,7 +189,12 @@ defmodule LoggerLogstashBackend do
   end
 
   defp open_socket(%{protocol: :tcp, socket: nil} = state) do
-    :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}])
+    :gen_tcp.connect(
+      state.host,
+      state.port,
+      [{:active, true}, :binary, {:keepalive, true}, {:send_timeout, 10_000}],
+      10_000
+    )
     |> case do
       {:ok, socket} -> Map.merge(state, %{socket: socket, recorded_error: false})
       {:error, reason} -> log_error(reason, state)

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -162,7 +162,7 @@ defmodule LoggerLogstashBackend do
   end
 
   defp log_error(error, %{recorded_error: false} = state) do
-    Logger.info(
+    Logger.error(
       "could not connect to logstash via #{inspect(state.protocol)}, reason: #{inspect(error)}"
     )
 

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -80,13 +80,17 @@ defmodule LoggerLogstashBackend do
 
     {:ok, datetime} = DateTime.from_naive(ts, timezone)
 
-    {:ok, json} =
-      json_encoder.encode(%{
-        type: type,
-        "@timestamp": DateTime.to_iso8601(datetime),
-        message: to_string(msg),
-        fields: fields
-      })
+    message =
+      Map.merge(
+        %{
+          type: type,
+          "@timestamp": DateTime.to_iso8601(datetime),
+          message: to_string(msg)
+        },
+        fields
+      )
+
+    {:ok, json} = json_encoder.encode(message)
 
     send_log(state, json)
   end

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -146,7 +146,7 @@ defmodule LoggerLogstashBackend do
     {:ok, socket} =
       :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}])
 
-    socket = :ssl.connect(socket, fail_if_no_peer_cert: true)
+    {:ok, socket} = :ssl.connect(socket, fail_if_no_peer_cert: true)
     Map.put(state, :socket, socket)
   end
 

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -16,11 +16,14 @@
 defmodule LoggerLogstashBackend do
   @behaviour :gen_event
 
+  require Logger
+
   def init({__MODULE__, name}) do
     {:ok, configure(name, [])}
   end
 
-  def handle_call({:configure, opts}, %{name: name}) do
+  def handle_call({:configure, opts}, %{name: name} = state) do
+    close_socket(state)
     {:ok, :ok, configure(name, opts)}
   end
 
@@ -36,11 +39,13 @@ defmodule LoggerLogstashBackend do
         {level, _gl, {Logger, msg, ts, md}},
         %{level: min_level} = state
       ) do
+    new_state = open_socket(state)
+
     if is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt do
-      log_event(level, msg, ts, md, state)
+      log_event(level, msg, ts, md, new_state)
     end
 
-    {:ok, state}
+    {:ok, new_state}
   end
 
   def code_change(_old_vsn, state, _extra) do
@@ -95,6 +100,8 @@ defmodule LoggerLogstashBackend do
     send_log(state, json)
   end
 
+  defp send_log(%{socket: nil}, _json), do: nil
+
   defp send_log(%{protocol: :udp, socket: socket, host: host, port: port}, json) do
     :ok = :gen_udp.send(socket, host, port, [json, "\n"])
   end
@@ -136,30 +143,59 @@ defmodule LoggerLogstashBackend do
       timezone: timezone,
       json_encoder: json_encoder,
       protocol: protocol,
-      ssl: ssl
+      ssl: ssl,
+      socket: nil
     }
-    |> open_socket()
   end
 
-  defp open_socket(%{protocol: :udp} = state) do
-    {:ok, socket} = :gen_udp.open(0)
-    Map.put(state, :socket, socket)
+  defp close_socket(%{socket: nil} = state), do: state
+
+  defp close_socket(%{protocol: :udp} = state) do
+    :ok = :gen_udp.close(state.socket)
+    %{state | socket: nil}
   end
 
-  defp open_socket(%{protocol: :tcp, ssl: true} = state) do
-    {:ok, socket} =
-      :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}])
-
-    {:ok, socket} = :ssl.connect(socket, fail_if_no_peer_cert: true)
-    Map.put(state, :socket, socket)
+  defp close_socket(%{protocol: :tcp} = state) do
+    :gen_tcp.shutdown(state.socket, :write)
+    %{state | socket: nil}
   end
 
-  defp open_socket(%{protocol: :tcp} = state) do
-    {:ok, socket} =
-      :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}])
+  defp open_socket(%{protocol: :udp, socket: nil} = state) do
+    case :gen_udp.open(0) do
+      {:ok, socket} ->
+        Map.put(state, :socket, socket)
 
-    Map.put(state, :socket, socket)
+      {:error, reason} ->
+        Logger.info("could not connect to logstash via udp, reason: #{inspect(reason)}")
+        state
+    end
   end
+
+  defp open_socket(%{protocol: :tcp, ssl: true, socket: nil} = state) do
+    with {:ok, socket} <-
+           :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}]),
+         {:ok, socket} <- :ssl.connect(socket, fail_if_no_peer_cert: true) do
+      Map.put(state, :socket, socket)
+    else
+      {:error, reason} ->
+        Logger.info("could not connect via tcp (with ssl), reason: #{inspect(reason)}")
+        state
+    end
+  end
+
+  defp open_socket(%{protocol: :tcp, socket: nil} = state) do
+    :gen_tcp.connect(state.host, state.port, [{:active, true}, :binary, {:keepalive, true}])
+    |> case do
+      {:ok, socket} ->
+        Map.put(state, :socket, socket)
+
+      {:error, reason} ->
+        Logger.info("could not connect via tcp, reason: #{inspect(reason)}")
+        state
+    end
+  end
+
+  defp open_socket(state), do: state
 
   # inspects the argument only if it is a pid
   defp inspect_pid(pid) when is_pid(pid), do: inspect(pid)

--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -92,15 +92,15 @@ defmodule LoggerLogstashBackend do
   end
 
   defp send_log(%{protocol: :udp, socket: socket, host: host, port: port}, json) do
-    :gen_udp.send(socket, host, port, [json, "\n"])
+    :ok = :gen_udp.send(socket, host, port, [json, "\n"])
   end
 
   defp send_log(%{protocol: :tcp, ssl: true, socket: socket}, json) do
-    :ssl.send(socket, [json, "\n"])
+    :ok = :ssl.send(socket, [json, "\n"])
   end
 
   defp send_log(%{protocol: :tcp, socket: socket}, json) do
-    :gen_tcp.send(socket, [json, "\n"])
+    :ok = :gen_tcp.send(socket, [json, "\n"])
   end
 
   defp configure(name, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule LoggerLogstashBackend.Mixfile do
       name: "logger_logstash_backend",
       source_url: "https://github.com/marcelog/logger_logstash_backend",
       version: "5.0.0",
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       description: description(),
       package: package(),
       deps: deps()

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule LoggerLogstashBackend.Mixfile do
     [
       {:earmark, "~> 1.0.3", only: :dev},
       {:ex_doc, "~> 0.14.5", only: :dev},
-      {:jason, "~> 1.0", only: [:dev, :test]}
+      {:jason, "~> 1.0", only: [:test]}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,26 +2,27 @@ defmodule LoggerLogstashBackend.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :logger_logstash_backend,
-     name: "logger_logstash_backend",
-     source_url: "https://github.com/marcelog/logger_logstash_backend",
-     version: "5.0.0",
-     elixir: "~> 1.3",
-     description: description(),
-     package: package(),
-     deps: deps()]
+    [
+      app: :logger_logstash_backend,
+      name: "logger_logstash_backend",
+      source_url: "https://github.com/marcelog/logger_logstash_backend",
+      version: "5.0.0",
+      elixir: "~> 1.3",
+      description: description(),
+      package: package(),
+      deps: deps()
+    ]
   end
 
   def application do
-    [applications: [:logger, :timex, :exjsx]]
+    [applications: [:logger]]
   end
 
   defp deps do
     [
       {:earmark, "~> 1.0.3", only: :dev},
       {:ex_doc, "~> 0.14.5", only: :dev},
-      {:exjsx, "~> 3.2.1"},
-      {:timex, "~> 3.1.8"}
+      {:jason, "~> 1.0", only: [:dev, :test]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+%{
+  "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "combine": {:hex, :combine, "0.9.6", "8d1034a127d4cbf6924c8a5010d3534d958085575fa4d9b878f200d79ac78335", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
@@ -6,9 +7,11 @@
   "gettext": {:hex, :gettext, "0.13.0", "daafbddc5cda12738bb93b01d84105fe75b916a302f1c50ab9fb066b95ec9db4", [:mix], []},
   "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "timex": {:hex, :timex, "3.1.8", "a32f636c4260dd7515a3767be3d3a163dc09d15f0e9e689254b7bab152b29209", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
-  "tzdata": {:hex, :tzdata, "0.5.10", "087e8dfe8c0283473115ad8ca6974b898ecb55ca5c725427a142a79593391e90", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}
+  "tzdata": {:hex, :tzdata, "0.5.10", "087e8dfe8c0283473115ad8ca6974b898ecb55ca5c725427a142a79593391e90", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -1,17 +1,5 @@
 %{
-  "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
-  "combine": {:hex, :combine, "0.9.6", "8d1034a127d4cbf6924c8a5010d3534d958085575fa4d9b878f200d79ac78335", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
-  "gettext": {:hex, :gettext, "0.13.0", "daafbddc5cda12738bb93b01d84105fe75b916a302f1c50ab9fb066b95ec9db4", [:mix], []},
-  "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
-  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []},
-  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
-  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "timex": {:hex, :timex, "3.1.8", "a32f636c4260dd7515a3767be3d3a163dc09d15f0e9e689254b7bab152b29209", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
-  "tzdata": {:hex, :tzdata, "0.5.10", "087e8dfe8c0283473115ad8ca6974b898ecb55ca5c725427a142a79593391e90", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
 }

--- a/test/logger_logstash_backend_test.exs
+++ b/test/logger_logstash_backend_test.exs
@@ -58,8 +58,8 @@ defmodule LoggerLogstashBackendTest do
       "key1" => "field1"
     }
 
-    assert data["fields"]["line"] == expected["line"]
-    assert contains?(data["fields"], expected)
+    assert data["line"] == expected["line"]
+    assert contains?(data, expected)
     {:ok, dt, _tz_offset} = DateTime.from_iso8601(data["@timestamp"])
     ts = DateTime.to_unix(dt)
 
@@ -84,8 +84,8 @@ defmodule LoggerLogstashBackendTest do
       "line" => 71
     }
 
-    assert data["fields"]["line"] == expected["line"]
-    assert contains?(data["fields"], expected)
+    assert data["line"] == expected["line"]
+    assert contains?(data, expected)
     {:ok, dt, _tz_offset} = DateTime.from_iso8601(data["@timestamp"])
     ts = DateTime.to_unix(dt)
 


### PR DESCRIPTION
I installed this yesterday and noticed that the milliseconds were missing from all my timestamps. This PR fixes that issue. I've also modernized the date / time handling code and made the JSON encoder module configurable (also changed the default to `Jason`).

I've updated the TravisCI config to remove Elixir 1.3.0 from the build targets.