### PR TITLE
PR: send payloads as binaries instead of char code lists

### DIFF
--- a/lib/logger_logstash_backend.ex
+++ b/lib/logger_logstash_backend.ex
@@ -76,7 +76,7 @@ defmodule LoggerLogstashBackend do
       message: to_string(msg),
       fields: fields
     }
-    :gen_udp.send socket, host, port, to_charlist(json)
+    :gen_udp.send socket, host, port, json
   end
 
   defp configure(name, opts) do

--- a/test/logger_logstash_backend_test.exs
+++ b/test/logger_logstash_backend_test.exs
@@ -84,6 +84,13 @@ defmodule LoggerLogstashBackendTest do
     assert (now - ts) < 1000
   end
 
+  test "can log with unicode" do
+    Logger.info "hëłłö worlð"
+    json = get_log()
+    {:ok, data} = JSX.decode json
+    assert data["message"] === "hëłłö worlð"
+  end
+
   test "cant log when minor levels" do
     Logger.debug "hello world", [key1: "field1"]
     :nothing_received = get_log()


### PR DESCRIPTION
`to_charlist` will drop the leading UTF-8 header bytes, resulting in parse errors for the logstash consumer